### PR TITLE
Use the latest Single Consent API client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ govuk_publishing_components:
 .PHONY: consent_api
 consent_api:
 	mkdir -p $(STATIC)/javascripts
-	cp node_modules/@alphagov/consent-api/client/src/*.js $(STATIC)/javascripts/
+	cp node_modules/@alphagov/consent-api/client/src/singleconsent.js $(STATIC)/javascripts/
+	cp node_modules/@alphagov/consent-api/client/example/*.js $(STATIC)/javascripts/
 
 .PHONY: assets
 assets: govuk_frontend govuk_publishing_components consent_api

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "node": ">=18.12.1"
   },
   "dependencies": {
-    "@alphagov/consent-api": "alphagov/consent-api#semver:1.6.0",
+    "@alphagov/consent-api": "alphagov/consent-api#semver:1.10.0",
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.3",

--- a/sde_prototype_govuk/assets.py
+++ b/sde_prototype_govuk/assets.py
@@ -48,7 +48,7 @@ application_css = Bundle(
 
 application_js = Bundle(
     "javascripts/utils.js",
-    "javascripts/consent.js",
+    "javascripts/singleconsent.js",
     "javascripts/cookie-banner.js",
     "javascripts/cookies-page.js",
     filters=[

--- a/sde_prototype_govuk/templates/base.html
+++ b/sde_prototype_govuk/templates/base.html
@@ -40,7 +40,7 @@
     'ariaLabel': 'Cookies on GOV.UK',
     'attributes': {
       'data-module': 'govuk-cookie-banner consent',
-      'data-consent-api-url': getenv('CONSENT_API_URL')
+      'data-consent-api-url': getenv('CONSENT_API_URL', 'https://consent-api-bgzqvpmbyq-nw.a.run.app/api/v1/consent/')
     },
     'messages': [
       {


### PR DESCRIPTION
* Provides the improved cross-origin link decoration
* Installation process changed slightly